### PR TITLE
chore: add release wf which updates major version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       TAG_NAME:
-        description: "Tag name that the major tag will point to"
+        description: 'Tag name that the major tag will point to'
         required: true
 
 env:
@@ -15,7 +15,9 @@ permissions:
 
 jobs:
   update_tag:
-    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    name:
+      Update the major tag to include the ${{ github.event.inputs.TAG_NAME ||
+      github.event.release.tag_name }} changes
     environment:
       name: releaseNewActionVersion
     runs-on: warp-ubuntu-latest-x64-2x

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,27 @@
+name: Release new action version
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: "Tag name that the major tag will point to"
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+permissions:
+  contents: write
+
+jobs:
+  update_tag:
+    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
+      name: releaseNewActionVersion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update the ${{ env.TAG_NAME }} tag
+        id: update-major-tag
+        uses: actions/publish-action@v0.3.0
+        with:
+          source-tag: ${{ env.TAG_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
     environment:
       name: releaseNewActionVersion
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
         id: update-major-tag


### PR DESCRIPTION
## Desc

Adds a release workflow which points the major version tag to the latest version in scope of the major version tag.